### PR TITLE
lcd1602 uses I2C1, not I2C0

### DIFF
--- a/docs/source/pyproject/py_lcd.rst
+++ b/docs/source/pyproject/py_lcd.rst
@@ -17,7 +17,7 @@ Therefore, LCD1602 with an I2C bus is developed to solve the problem.
 
 |pin_i2c|
 
-Here we will use the I2C0 interface to control the LCD1602 and display text.
+Here we will use the I2C1 interface to control the LCD1602 and display text.
 
 
 **Required Components**


### PR DESCRIPTION
In https://github.com/sunfounder/kepler-kit/blob/main/libs/lcd1602.py#L8 , the bus is initialized as `machine.I2C(1, ...` which is I2C1 (so GP6 and 7, like on the wiring diagram) rather than I2C0 (GP3 and 4)